### PR TITLE
Update to use https for pulling source

### DIFF
--- a/vars/default.yml
+++ b/vars/default.yml
@@ -10,7 +10,7 @@
     - curl
 
 
-  uhp_repo: http://github.com/MattCarothers/uhp
+  uhp_repo: https://github.com/MattCarothers/uhp
 
   uhp_dir: /opt/uhp
   uhp_user: uhp


### PR DESCRIPTION
Should resolve #1 partially. Currently there are no tagged releases for UHP, but have filed https://github.com/MattCarothers/uhp/issues/2 in order to request some.